### PR TITLE
Добавил тесты по объектам данных с возможностью перегенерации

### DIFF
--- a/src/SuperSimpleContactList/IntegrationTests/DataObjectFacts.Regenerated.cs
+++ b/src/SuperSimpleContactList/IntegrationTests/DataObjectFacts.Regenerated.cs
@@ -1,0 +1,21 @@
+﻿namespace NewPlatform.SuperSimpleContactList
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    public partial class DataObjectFacts
+    {
+        /// <summary>
+        /// Получить классы объектов данных,
+        /// которые не требуется вычитывать из БД.
+        /// </summary>
+        /// <returns>Список классов, которые не требуется вычитывать из БД.</returns>
+        private partial IEnumerable<Type> GetNotSelectableTypes()
+        {
+            return Enumerable.Empty<Type>();
+        }
+    }
+}

--- a/src/SuperSimpleContactList/IntegrationTests/DataObjectFacts.cs
+++ b/src/SuperSimpleContactList/IntegrationTests/DataObjectFacts.cs
@@ -1,0 +1,156 @@
+﻿namespace NewPlatform.SuperSimpleContactList
+{
+    using ICSSoft.STORMNET;
+    using ICSSoft.STORMNET.Business;
+    using ICSSoft.STORMNET.FunctionalLanguage;
+    using ICSSoft.STORMNET.Windows.Forms;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Xunit;
+    
+
+    public partial class DataObjectFacts
+    {
+
+        private readonly IDataService _dataService;
+
+        public DataObjectFacts(IDataService dataService) => _dataService = dataService;
+
+
+        #region Customizations
+
+        /// <summary>
+        /// Получить классы объектов данных,
+        /// которые не требуется вычитывать из БД.
+        /// </summary>
+        /// <returns>Список классов, которые не требуется вычитывать из БД.</returns>
+        private partial IEnumerable<Type> GetNotSelectableTypes();
+        #endregion
+
+        /// <summary>
+        /// Получить хранимые объекты данных из сборки объектов данных.
+        /// </summary>
+        /// <returns>Список классов хранимых объектов данных из сборки объектов данных.</returns>
+        private IEnumerable<Type> GetStoredDataObjects()
+        {
+            return Assembly.GetAssembly(typeof(ObjectsMarker))
+                .GetExportedTypes()
+                .Where(
+                    x => x.IsClass
+                         && x.IsSubclassOf(typeof(DataObject))
+                         && Information.IsStoredType(x))
+                .OrderBy(x => x.FullName);
+        }
+
+
+        /// <summary>
+        ///     Проверить, что все хранимые классы могут читаться по всем представлениям.
+        /// </summary>
+        [Fact]
+        public void CheckAllStoredClassesAreSelectable()
+        {
+            // Arrange.
+            var dontCheckClasses = GetNotSelectableTypes();
+            var storedTypes = GetStoredDataObjects().Except(dontCheckClasses).ToList();
+
+            // Act.
+            var errors = new Dictionary<string, string>();
+            foreach (var type in storedTypes)
+            {
+                var viewNames = Information.AllViews(type);
+                var viewOnlyThat = new View(type, View.ReadType.OnlyThatObject);
+                var views = viewNames.Select(x => Information.GetView(x, type)).Union(new[] { viewOnlyThat });
+                foreach (var view in views)
+                {
+
+                    try
+                    {
+                        var lcs = LoadingCustomizationStruct.GetSimpleStruct(type, view);
+                        lcs.ReturnTop = 1;
+                        _dataService.LoadObjects(lcs);
+                    }
+                    catch (Exception ex)
+                    {
+                        while (ex.InnerException != null)
+                        {
+                            ex = ex.InnerException;
+                        }
+
+                        string key = $"{type.FullName}\t{view.Name}";
+                        errors[key] = ex.Message;
+                    }
+                }
+            }
+
+            // Assert.
+            Assert.False(
+                errors.Any(),
+                string.Join(Environment.NewLine, errors.OrderBy(x => x.Key).Select(x => $"{x.Key}:{Environment.NewLine}{x.Value}")));
+        }
+
+        /// <summary>
+        ///     Проверить, что все хранимые классы имеют корректную интеграцию по полям Enum.
+        /// </summary>
+        [Fact]
+        public void CheckAllEnumIntegration()
+        {
+            // Arrange.
+            var storedTypes = GetStoredDataObjects().ToList();
+            var storedTypesWithEnum = storedTypes.Where(x => x.GetProperties().Any(p => p.PropertyType.IsEnum));
+
+            // Act.
+            var errors = new Dictionary<string, string>();
+            foreach (var type in storedTypesWithEnum)
+            {
+                var enumProps = type.GetProperties().Where(p => p.PropertyType.IsEnum && Information.IsStoredProperty(type, p.Name));
+                foreach (var prop in enumProps)
+                {
+                    var view = new View { DefineClassType = type };
+                    view.AddProperty(prop.Name);
+
+                    var enumCaptions = Enum.GetValues(prop.PropertyType).Cast<object>().Select(EnumCaption.GetCaptionFor).ToList();
+
+                    try
+                    {
+                        // Вычитаем из БД все строки, у которых `prop.Name` не пусто и не из списка доступных `Caption`.
+                        var varDef = new VariableDef(ExternalLangDef.LanguageDef.StringType, prop.Name);
+                        var lcs = LoadingCustomizationStruct.GetSimpleStruct(type, view);
+                        lcs.LimitFunction = FunctionBuilder.BuildAnd(
+                            FunctionBuilder.BuildIsNotNull(prop.Name),
+                            FunctionBuilder.BuildNot(
+                                FunctionBuilder.BuildOr(enumCaptions.Select(x => FunctionBuilder.BuildEquals(varDef, x)))));
+                        int failedObjects = _dataService.GetObjectsCount(lcs);
+
+                        // Можно посчитать только кол-во, ибо сами объекты не получится загрузить (ошибка парсинга Enum).
+                        // Можно попробовать вытащить сырые значения через LoadStringedObjectView, но проще от этого не станет.
+                        if (failedObjects > 0)
+                        {
+                            string key = $"{type.FullName}.{prop.Name}\t{prop.PropertyType}";
+                            string sql = (_dataService as SQLDataService)?.GenerateSQLSelect(lcs, false) ?? "";
+                            errors[key] = $"Обнаружено {failedObjects} объектов не соответствующих {prop.PropertyType}:{Environment.NewLine}{sql}";
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        while (ex.InnerException != null)
+                        {
+                            ex = ex.InnerException;
+                        }
+
+                        string key = $"{type.FullName}.{prop.Name}\t{prop.PropertyType}";
+                        errors[key] = ex.Message;
+                    }
+                }
+            }
+
+            // Assert.
+            Assert.False(
+                errors.Any(),
+                string.Join(Environment.NewLine, errors.OrderBy(x => x.Key).Select(x => $"{x.Key}:{Environment.NewLine}{x.Value}")));
+        }
+    }
+}

--- a/src/SuperSimpleContactList/IntegrationTests/Startup.cs
+++ b/src/SuperSimpleContactList/IntegrationTests/Startup.cs
@@ -1,0 +1,29 @@
+﻿/*
+ * Пришлось сменить неймспейс, потому что иначе XUnit.DependencyInjection версии 7.х не может подтянуть startup-класс.
+ * В версии 7.х в отличие от предыдущих версий этим поведением нельзя управлять.
+ */
+namespace SuperSimpleContactList.IntegrationTests
+{
+
+    using ICSSoft.STORMNET.Business;
+    using ICSSoft.STORMNET.Security;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
+
+    public class Startup
+    {
+        public void ConfigureHost(IHostBuilder hostBuilder) =>
+            hostBuilder
+                .ConfigureHostConfiguration(builder => { builder.AddJsonFile("appsettings.json"); })
+                .ConfigureAppConfiguration((context, builder) => { });
+
+        public void ConfigureServices(IServiceCollection services, HostBuilderContext context)
+        {
+            string connStr =context.Configuration["DefConnStr"];
+            services.AddSingleton<ISecurityManager, EmptySecurityManager>();
+            services.AddSingleton<IDataService, PostgresDataService>(f => new PostgresDataService(f.GetService<ISecurityManager>()) { CustomizationString = connStr });
+
+        }
+    }
+}

--- a/src/SuperSimpleContactList/IntegrationTests/SuperSimpleContactList.IntegrationTests.csproj
+++ b/src/SuperSimpleContactList/IntegrationTests/SuperSimpleContactList.IntegrationTests.csproj
@@ -11,13 +11,24 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
   </ItemGroup>
   <ItemGroup>
+    <None Remove="appsettings.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Include="Moq" Version="4.15.2" />
     <PackageReference Include="NewPlatform.Flexberry.ORM" Version="6.0.0-beta14" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM.PostgresDataService" Version="6.0.0-beta12" />
     <PackageReference Include="NewPlatform.Flexberry.StyleCopRuleset" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Xunit.DependencyInjection" Version="7.1.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/SuperSimpleContactList/IntegrationTests/appsettings.json
+++ b/src/SuperSimpleContactList/IntegrationTests/appsettings.json
@@ -1,0 +1,4 @@
+{
+  "DefConnStr": "",
+  "UploadUrl": "Uploads"
+}

--- a/src/SuperSimpleContactList/ODataBackend/Startup.cs
+++ b/src/SuperSimpleContactList/ODataBackend/Startup.cs
@@ -109,7 +109,7 @@
 
                 var assemblies = new[]
                 {
-                    typeof(Contact).Assembly,
+                    typeof(ObjectsMarker).Assembly,
                     typeof(ApplicationLog).Assembly,
                     typeof(UserSetting).Assembly,
                     typeof(Lock).Assembly,

--- a/src/SuperSimpleContactList/Objects/Contact.cs
+++ b/src/SuperSimpleContactList/Objects/Contact.cs
@@ -31,6 +31,7 @@ namespace NewPlatform.SuperSimpleContactList
         "ers", ICSSoft.STORMNET.Business.DataServiceObjectEvents.OnAllEvents)]
     [PublishName("Contact")]
     [AutoAltered()]
+    [Serializable]
     [Caption("Personal contact")]
     [AccessType(ICSSoft.STORMNET.AccessType.none)]
     [View("ContactE", new string[] {

--- a/src/SuperSimpleContactList/Objects/ObjectsMarker.cs
+++ b/src/SuperSimpleContactList/Objects/ObjectsMarker.cs
@@ -1,0 +1,9 @@
+﻿namespace NewPlatform.SuperSimpleContactList
+{
+    /// <summary>
+    /// Класс для получения сборки с объектами в DI.
+    /// </summary>
+    public sealed class ObjectsMarker
+    {
+    }
+}

--- a/src/SuperSimpleContactList/Tests/DataObjectFacts.Regenerated.cs
+++ b/src/SuperSimpleContactList/Tests/DataObjectFacts.Regenerated.cs
@@ -383,5 +383,28 @@ namespace NewPlatform.SuperSimpleContactList
                 errors.Any(),
                 $"{Environment.NewLine}В следующих представлениях обнаружены ошибки нехранимых свойств:{Environment.NewLine}{string.Join(Environment.NewLine, errors)}");
         }
+
+        /// <summary>
+        ///     Тест проверяет, что у всех классов присутствует атрибут <see cref="SerializableAttribute" />.
+        /// </summary>
+        [Fact]
+        public void TestAllDataObjectHasSerializableAttribute()
+        {
+            // Arrange.
+            var types = Assembly.GetAssembly(typeof(ObjectsMarker)).GetExportedTypes();
+
+            // Act.
+            var notSerializableTypes = types.Where(
+                x => x.IsClass
+                     && (x.IsSubclassOf(typeof(DataObject)) || x.IsSubclassOf(typeof(DetailArray)))
+                     && !x.IsSerializable)
+                .Select(x => x.FullName)
+                .ToList();
+
+            // Assert.
+            Assert.False(
+                notSerializableTypes.Any(),
+                $"{Environment.NewLine}У классов отсутствует атрибут [Serializable]:{Environment.NewLine}{string.Join(Environment.NewLine, notSerializableTypes)}");
+        }
     }
 }

--- a/src/SuperSimpleContactList/Tests/DataObjectFacts.Regenerated.cs
+++ b/src/SuperSimpleContactList/Tests/DataObjectFacts.Regenerated.cs
@@ -1,0 +1,74 @@
+﻿/*
+ * Этот файл генерируется каждый раз при генерации проекта объектов.
+ * Не нужно вносить изменения в этот файл вручную.
+ * Настроить поведение тестов можно в соседнем файле,
+ * который генерируется только при первой генерации.
+ */
+
+namespace NewPlatform.SuperSimpleContactList
+{
+    using ICSSoft.STORMNET;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    public partial class DataObjectFacts
+    {
+        #region Customizations
+        private partial Dictionary<Type, string[]> GetPropertyWithoutDataServiceExpression();
+
+        private partial Type GetDataServiceType();
+        #endregion
+
+        private IEnumerable<Type> GetObjects()
+        {
+            return Assembly.GetAssembly(typeof(ObjectsMarker))
+                .GetExportedTypes()
+                .Where(
+                    x => x.IsClass
+                         && x.IsSubclassOf(typeof(DataObject))
+                         && Information.IsStoredType(x))
+                .OrderBy(x => x.FullName);
+        }
+
+        /// <summary>
+        ///     Тест проверяет, что все нехранимые свойства имеют DSE.
+        /// </summary>
+        [Fact]
+        public void TestAllNotStoredPropertiesHaveDataServiceExpression()
+        {
+            // Arrange.
+            var dataServiceType = GetDataServiceType();
+            var assemblyClasses = GetObjects();
+            var dontCheckDict = GetPropertyWithoutDataServiceExpression();
+            var dontCheckPropertyNames = typeof(DataObject).GetProperties()
+                .Where(o => !Information.IsStoredProperty(typeof(DataObject), o.Name))
+                .Select(o => o.Name);
+
+            // Act.
+            var errors = new List<string>();
+            foreach (var cl in assemblyClasses)
+            {
+                var classProperties = cl.GetProperties()
+                    .Where(// Не проверяем исключения на имя свойства.
+                        o => !dontCheckPropertyNames.Contains(o.Name))
+                    .Where(// Не проверяем пары имя свойства + класс.
+                        o => !(dontCheckDict.ContainsKey(cl) && dontCheckDict[cl].Contains(o.Name)))
+                    .Where(
+                        o => !Information.IsStoredProperty(cl, o.Name)
+                             && string.IsNullOrEmpty(Information.GetExpressionForProperty(cl, o.Name).GetMostCompatible(dataServiceType)?.ToString())
+                             && !o.PropertyType.IsSubclassOf(typeof(DataObject)));
+                errors.AddRange(classProperties.Select(prop => $"{cl.FullName}.{prop.Name}"));
+            }
+
+            // Assert.
+            Assert.False(
+                errors.Any(),
+                $"{Environment.NewLine}Следующие нехранимые свойства классов не имеют DSE:{Environment.NewLine}{string.Join(Environment.NewLine, errors)}");
+        }
+    }
+}

--- a/src/SuperSimpleContactList/Tests/DataObjectFacts.Regenerated.cs
+++ b/src/SuperSimpleContactList/Tests/DataObjectFacts.Regenerated.cs
@@ -310,5 +310,39 @@ namespace NewPlatform.SuperSimpleContactList
                 errors.Any(),
                 $"{Environment.NewLine}У следующих классов Views-subclass некорректны:{Environment.NewLine}{string.Join(Environment.NewLine, errors)}");
         }
+
+        /// <summary>
+        ///     Тест проверяет, что во всех представлениях детейлов присутствует свойство агрегатора.
+        /// </summary>
+        [Fact]
+        public void TestDetailViews()
+        {
+            // Arrange.
+            var assemblyClasses = GetStoredDataObjects();
+            var errors = new List<string>();
+
+            // Act.
+            foreach (var type in assemblyClasses)
+            {
+                string agrProp = Information.GetAgregatePropertyName(type);
+                if (string.IsNullOrEmpty(agrProp))
+                    continue;
+
+                var viewNames = Information.AllViews(type);
+                foreach (string viewName in viewNames)
+                {
+                    var view = Information.GetView(viewName, type);
+                    if (view.Properties.All(p => p.Name != agrProp))
+                    {
+                        errors.Add($"{type.FullName} {viewName}");
+                    }
+                }
+            }
+
+            // Assert.
+            Assert.False(
+                errors.Any(),
+                $"{Environment.NewLine}В следующих представлениях детейловых классов не найдены свойство агрегатора:{Environment.NewLine}{string.Join(Environment.NewLine, errors)}");
+        }
     }
 }

--- a/src/SuperSimpleContactList/Tests/DataObjectFacts.Regenerated.cs
+++ b/src/SuperSimpleContactList/Tests/DataObjectFacts.Regenerated.cs
@@ -14,8 +14,6 @@ namespace NewPlatform.SuperSimpleContactList
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
-    using System.Text;
-    using System.Threading.Tasks;
     using Xunit;
 
     public partial class DataObjectFacts

--- a/src/SuperSimpleContactList/Tests/DataObjectFacts.Regenerated.cs
+++ b/src/SuperSimpleContactList/Tests/DataObjectFacts.Regenerated.cs
@@ -21,23 +21,68 @@ namespace NewPlatform.SuperSimpleContactList
     public partial class DataObjectFacts
     {
         #region Customizations
+
+        /// <summary>
+        /// Получить используемый приложением тип сервиса данных.
+        /// </summary>
+        /// <returns>Тип сервиса данных.</returns>
         private partial Type GetDataServiceType();
 
-        private partial Dictionary<Type, string[]> GetPropertyWithoutDataServiceExpression();
+        /// <summary>
+        /// Получить имена свойств объектов данных,
+        /// для которых намеренно не задано DataServiceExpression.
+        /// </summary>
+        /// <returns>Словарь {Тип, массив имен свойств}, для которых не задано DataServiceExpression.</returns>
+        private partial Dictionary<Type, string[]> GetPropertiesWithoutDataServiceExpression();
 
-        private partial Dictionary<Type, string[]> GetPropertyWithoutNotNull();
+        /// <summary>
+        /// Получить имена свойств объектов данных с ValueType-типом,
+        /// для которых намеренно не задан атрибут <see cref="NotNullAttribute"/>.
+        /// </summary>
+        /// <returns>Словарь {Тип, массив имен свойств}, для которых намеренно не задан атрибут <see cref="NotNullAttribute"/>.</returns>
+        private partial Dictionary<Type, string[]> GetPropertiesWithoutNotNull();
 
-        private partial Dictionary<Type, string[]> GetPropertyWithoutGetterCheck();
+        /// <summary>
+        /// Получить имена свойств объектов данных,
+        /// у которых геттер намеренно генерирует исключение, если объект недозагружен.
+        /// </summary>
+        /// <returns>Словарь {Тип, массив имен свойств}, у которых геттер намеренно генерирует исключение, если объект недозагружен.</returns>
+        private partial Dictionary<Type, string[]> GetPropertiesWithoutGetterCheck();
 
-        private partial Dictionary<Type, string[]> GetPropertyWithoutSetterCheck();
+        /// <summary>
+        /// Получить имена свойств объектов данных,
+        /// у которых сеттер намеренно генерирует исключение, если объект недозагружен.
+        /// </summary>
+        /// <returns>Словарь {Тип, массив имен свойств}, у которых сеттер намеренно генерирует исключение, если объект недозагружен.</returns>
+        private partial Dictionary<Type, string[]> GetPropertiesWithoutSetterCheck();
 
-        private partial IEnumerable<Type> GetTypesWithoutValidViews();
+        /// <summary>
+        /// Получить классы объектов данных, 
+        /// в которых имеются намеренно некорректные представления.
+        /// </summary>
+        /// <returns>Список классов с намеренно некорректными представлениями.</returns>
+        private partial IEnumerable<Type> GetTypesWithInvalidViews();
 
+        /// <summary>
+        /// Получить классы объектов данных,
+        /// в которых намеренно не задан AcessType=@this.
+        /// </summary>
+        /// <returns>Список классов, в которых намеренно не задан AcessType=@this.</returns>
         private partial IEnumerable<Type> GetDataObjectsWithoutAccessType();
 
+        /// <summary>
+        /// Получить классы объектов данных,
+        /// в которых намеренно не настроен аудит.
+        /// </summary>
+        /// <returns>Список классов, в которых намеренно не настроен аудит.</returns>
         private partial IEnumerable<Type> GetDataObjectsWithoutAudit();
 
-        private partial IEnumerable<Type> GetDataObjectsWithoutAuditOperation();
+        /// <summary>
+        /// Получить классы объектов данных,
+        /// в которых намеренно не настроен аудит операций.
+        /// </summary>
+        /// <returns>Список классов, в которых намеренно не настроен аудит операций.</returns>
+        private partial IEnumerable<Type> GetDataObjectsWithoutAuditOperations();
         #endregion
 
         /// <summary>
@@ -87,7 +132,7 @@ namespace NewPlatform.SuperSimpleContactList
             // Arrange.
             var dataServiceType = GetDataServiceType();
             var assemblyClasses = GetStoredDataObjects();
-            var dontCheckDict = GetPropertyWithoutDataServiceExpression();
+            var dontCheckDict = GetPropertiesWithoutDataServiceExpression();
             var dontCheckPropertyNames = typeof(DataObject).GetProperties()
                 .Where(o => !Information.IsStoredProperty(typeof(DataObject), o.Name))
                 .Select(o => o.Name);
@@ -122,7 +167,7 @@ namespace NewPlatform.SuperSimpleContactList
         {
             // Arrange.
             var assemblyClasses = GetStoredDataObjects();
-            var dontCheckDict = GetPropertyWithoutNotNull();
+            var dontCheckDict = GetPropertiesWithoutNotNull();
 
             // Act.
             var errors = new List<string>();
@@ -158,7 +203,7 @@ namespace NewPlatform.SuperSimpleContactList
         {
             // Arrange.
             var assemblyClasses = GetStoredDataObjects();
-            var dontCheckDict = GetPropertyWithoutGetterCheck();
+            var dontCheckDict = GetPropertiesWithoutGetterCheck();
 
             // Act.
             var errors = new List<string>();
@@ -197,7 +242,7 @@ namespace NewPlatform.SuperSimpleContactList
         {
             // Arrange.
             var assemblyClasses = GetStoredDataObjects();
-            var dontCheckDict = GetPropertyWithoutSetterCheck();
+            var dontCheckDict = GetPropertiesWithoutSetterCheck();
 
             // Act.
             var errors = new List<string>();
@@ -309,7 +354,7 @@ namespace NewPlatform.SuperSimpleContactList
         public void TestStaticViewsAreValid()
         {
             // Arrange.
-            var dontCheckClasses = GetTypesWithoutValidViews();
+            var dontCheckClasses = GetTypesWithInvalidViews();
             var assemblyClasses = GetStoredDataObjects();
             var checkedTypes = assemblyClasses.Where(x => !dontCheckClasses.Contains(x)).ToList();
 
@@ -506,7 +551,7 @@ namespace NewPlatform.SuperSimpleContactList
             var errorMessages = new List<string>();
 
             var exceptionsGlobal = GetDataObjectsWithoutAudit();
-            var exceptions = GetDataObjectsWithoutAuditOperation();
+            var exceptions = GetDataObjectsWithoutAuditOperations();
 
             var assemblyClasses = GetStoredDataObjects().Except(exceptionsGlobal).Except(exceptions);
 

--- a/src/SuperSimpleContactList/Tests/DataObjectFacts.cs
+++ b/src/SuperSimpleContactList/Tests/DataObjectFacts.cs
@@ -13,6 +13,11 @@ namespace NewPlatform.SuperSimpleContactList
     {
 
         /// <summary>
+        /// Проверять ли, что во всех объектах данных AcessType=@this.
+        /// </summary>
+        private bool CheckAccessTypeThis { get; } = false;
+
+        /// <summary>
         /// Получить используемый приложением тип сервиса данных.
         /// </summary>
         /// <returns>Тип сервиса данных.</returns>
@@ -61,9 +66,31 @@ namespace NewPlatform.SuperSimpleContactList
             return new Dictionary<Type, string[]>();
         }
 
+        /// <summary>
+        /// Получить классы объектов данных, 
+        /// в которых имеются намеренно некорректные представления.
+        /// </summary>
+        /// <returns>Список классов с намеренно некорректными представлениями.</returns>
         private partial IEnumerable<Type> GetTypesWithoutValidViews()
         {
             return Enumerable.Empty<Type>();
+        }
+
+        /// <summary>
+        /// Получить классы объектов данных,
+        /// в которых не задан AcessType=@this.
+        /// </summary>
+        /// <returns>Список классов, в которых не задан AcessType=@this.</returns>
+        private partial IEnumerable<Type> GetDataObjectsWithoutAccessType()
+        {
+            if (CheckAccessTypeThis)
+            {
+                return Enumerable.Empty<Type>();
+            }
+            else
+            {
+                return GetStoredDataObjects();
+            }
         }
     }
 }

--- a/src/SuperSimpleContactList/Tests/DataObjectFacts.cs
+++ b/src/SuperSimpleContactList/Tests/DataObjectFacts.cs
@@ -28,5 +28,15 @@ namespace NewPlatform.SuperSimpleContactList
         {
             return new Dictionary<Type, string[]>();
         }
+
+        /// <summary>
+        /// Получить имена свойств объектов данных,
+        /// для которых намеренно не задано DataServiceExpression.
+        /// </summary>
+        /// <returns>Словарь {Тип, массив имен свойств}, для которых не задано DataServiceExpression.</returns>
+        private partial Dictionary<Type, string[]> GetPropertyWithoutNotNull()
+        {
+            return new Dictionary<Type, string[]>();
+        }
     }
 }

--- a/src/SuperSimpleContactList/Tests/DataObjectFacts.cs
+++ b/src/SuperSimpleContactList/Tests/DataObjectFacts.cs
@@ -18,6 +18,11 @@ namespace NewPlatform.SuperSimpleContactList
         private bool CheckAccessTypeThis { get; } = false;
 
         /// <summary>
+        /// Проверять ли, что во всех объектах настроен аудит.
+        /// </summary>
+        private bool CheckAudit { get; } = false;
+
+        /// <summary>
         /// Получить используемый приложением тип сервиса данных.
         /// </summary>
         /// <returns>Тип сервиса данных.</returns>
@@ -78,12 +83,46 @@ namespace NewPlatform.SuperSimpleContactList
 
         /// <summary>
         /// Получить классы объектов данных,
-        /// в которых не задан AcessType=@this.
+        /// в которых намеренно не задан AcessType=@this.
         /// </summary>
-        /// <returns>Список классов, в которых не задан AcessType=@this.</returns>
+        /// <returns>Список классов, в которых намеренно не задан AcessType=@this.</returns>
         private partial IEnumerable<Type> GetDataObjectsWithoutAccessType()
         {
             if (CheckAccessTypeThis)
+            {
+                return Enumerable.Empty<Type>();
+            }
+            else
+            {
+                return GetStoredDataObjects();
+            }
+        }
+
+        /// <summary>
+        /// Получить классы объектов данных,
+        /// в которых намеренно не настроен аудит.
+        /// </summary>
+        /// <returns>Список классов, в которых намеренно не настроен аудит.</returns>
+        private partial IEnumerable<Type> GetDataObjectsWithoutAudit()
+        {
+            if (CheckAudit)
+            {
+                return Enumerable.Empty<Type>();
+            }
+            else
+            {
+                return GetStoredDataObjects();
+            }
+        }
+
+        /// <summary>
+        /// Получить классы объектов данных,
+        /// в которых намеренно не настроен аудит операций.
+        /// </summary>
+        /// <returns>Список классов, в которых намеренно не настроен аудит операций.</returns>
+        private partial IEnumerable<Type> GetDataObjectsWithoutAuditOperation()
+        {
+            if (CheckAudit)
             {
                 return Enumerable.Empty<Type>();
             }

--- a/src/SuperSimpleContactList/Tests/DataObjectFacts.cs
+++ b/src/SuperSimpleContactList/Tests/DataObjectFacts.cs
@@ -1,0 +1,32 @@
+﻿/*
+ * В этом файле можно настраивать поведение тестов.
+ */
+namespace NewPlatform.SuperSimpleContactList
+{
+    using System;
+    using System.Collections.Generic;
+    using ICSSoft.STORMNET.Business;
+
+    public partial class DataObjectFacts
+    {
+
+        /// <summary>
+        /// Получить используемый приложением тип сервиса данных.
+        /// </summary>
+        /// <returns>Тип сервиса данных.</returns>
+        private partial Type GetDataServiceType()
+        {
+            return typeof(PostgresDataService);
+        }
+
+        /// <summary>
+        /// Получить имена свойств объектов данных,
+        /// для которых намеренно не задано DataServiceExpression.
+        /// </summary>
+        /// <returns>Словарь {Тип, массив имен свойств}, для которых не задано DataServiceExpression.</returns>
+        private partial Dictionary<Type, string[]> GetPropertyWithoutDataServiceExpression()
+        {
+            return new Dictionary<Type, string[]>();
+        }
+    }
+}

--- a/src/SuperSimpleContactList/Tests/DataObjectFacts.cs
+++ b/src/SuperSimpleContactList/Tests/DataObjectFacts.cs
@@ -36,7 +36,7 @@ namespace NewPlatform.SuperSimpleContactList
         /// для которых намеренно не задано DataServiceExpression.
         /// </summary>
         /// <returns>Словарь {Тип, массив имен свойств}, для которых не задано DataServiceExpression.</returns>
-        private partial Dictionary<Type, string[]> GetPropertyWithoutDataServiceExpression()
+        private partial Dictionary<Type, string[]> GetPropertiesWithoutDataServiceExpression()
         {
             return new Dictionary<Type, string[]>();
         }
@@ -46,7 +46,7 @@ namespace NewPlatform.SuperSimpleContactList
         /// для которых намеренно не задан атрибут <see cref="NotNullAttribute"/>.
         /// </summary>
         /// <returns>Словарь {Тип, массив имен свойств}, для которых намеренно не задан атрибут <see cref="NotNullAttribute"/>.</returns>
-        private partial Dictionary<Type, string[]> GetPropertyWithoutNotNull()
+        private partial Dictionary<Type, string[]> GetPropertiesWithoutNotNull()
         {
             return new Dictionary<Type, string[]>();
         }
@@ -56,7 +56,7 @@ namespace NewPlatform.SuperSimpleContactList
         /// у которых геттер намеренно генерирует исключение, если объект недозагружен.
         /// </summary>
         /// <returns>Словарь {Тип, массив имен свойств}, у которых геттер намеренно генерирует исключение, если объект недозагружен.</returns>
-        private partial Dictionary<Type, string[]> GetPropertyWithoutGetterCheck()
+        private partial Dictionary<Type, string[]> GetPropertiesWithoutGetterCheck()
         {
             return new Dictionary<Type, string[]>();
         }
@@ -66,7 +66,7 @@ namespace NewPlatform.SuperSimpleContactList
         /// у которых сеттер намеренно генерирует исключение, если объект недозагружен.
         /// </summary>
         /// <returns>Словарь {Тип, массив имен свойств}, у которых сеттер намеренно генерирует исключение, если объект недозагружен.</returns>
-        private partial Dictionary<Type, string[]> GetPropertyWithoutSetterCheck()
+        private partial Dictionary<Type, string[]> GetPropertiesWithoutSetterCheck()
         {
             return new Dictionary<Type, string[]>();
         }
@@ -76,7 +76,7 @@ namespace NewPlatform.SuperSimpleContactList
         /// в которых имеются намеренно некорректные представления.
         /// </summary>
         /// <returns>Список классов с намеренно некорректными представлениями.</returns>
-        private partial IEnumerable<Type> GetTypesWithoutValidViews()
+        private partial IEnumerable<Type> GetTypesWithInvalidViews()
         {
             return Enumerable.Empty<Type>();
         }
@@ -120,7 +120,7 @@ namespace NewPlatform.SuperSimpleContactList
         /// в которых намеренно не настроен аудит операций.
         /// </summary>
         /// <returns>Список классов, в которых намеренно не настроен аудит операций.</returns>
-        private partial IEnumerable<Type> GetDataObjectsWithoutAuditOperation()
+        private partial IEnumerable<Type> GetDataObjectsWithoutAuditOperations()
         {
             if (CheckAudit)
             {

--- a/src/SuperSimpleContactList/Tests/DataObjectFacts.cs
+++ b/src/SuperSimpleContactList/Tests/DataObjectFacts.cs
@@ -5,6 +5,7 @@ namespace NewPlatform.SuperSimpleContactList
 {
     using System;
     using System.Collections.Generic;
+    using ICSSoft.STORMNET;
     using ICSSoft.STORMNET.Business;
 
     public partial class DataObjectFacts
@@ -30,11 +31,21 @@ namespace NewPlatform.SuperSimpleContactList
         }
 
         /// <summary>
-        /// Получить имена свойств объектов данных,
-        /// для которых намеренно не задано DataServiceExpression.
+        /// Получить имена свойств объектов данных с ValueType-типом,
+        /// для которых намеренно не задан атрибут <see cref="NotNullAttribute"/>.
         /// </summary>
-        /// <returns>Словарь {Тип, массив имен свойств}, для которых не задано DataServiceExpression.</returns>
+        /// <returns>Словарь {Тип, массив имен свойств}, для которых намеренно не задан атрибут <see cref="NotNullAttribute"/>.</returns>
         private partial Dictionary<Type, string[]> GetPropertyWithoutNotNull()
+        {
+            return new Dictionary<Type, string[]>();
+        }
+
+        /// <summary>
+        /// Получить имена свойств объектов данных,
+        /// у которых геттер намеренно генерирует исключение, если объект недозагружен.
+        /// </summary>
+        /// <returns>Словарь {Тип, массив имен свойств}, у которых геттер намеренно генерирует исключение, если объект недозагружен.</returns>
+        private partial Dictionary<Type, string[]> GetPropertyWithoutGetterCheck()
         {
             return new Dictionary<Type, string[]>();
         }

--- a/src/SuperSimpleContactList/Tests/DataObjectFacts.cs
+++ b/src/SuperSimpleContactList/Tests/DataObjectFacts.cs
@@ -49,5 +49,15 @@ namespace NewPlatform.SuperSimpleContactList
         {
             return new Dictionary<Type, string[]>();
         }
+
+        /// <summary>
+        /// Получить имена свойств объектов данных,
+        /// у которых сеттер намеренно генерирует исключение, если объект недозагружен.
+        /// </summary>
+        /// <returns>Словарь {Тип, массив имен свойств}, у которых сеттер намеренно генерирует исключение, если объект недозагружен.</returns>
+        private partial Dictionary<Type, string[]> GetPropertyWithoutSetterCheck()
+        {
+            return new Dictionary<Type, string[]>();
+        }
     }
 }

--- a/src/SuperSimpleContactList/Tests/DataObjectFacts.cs
+++ b/src/SuperSimpleContactList/Tests/DataObjectFacts.cs
@@ -5,6 +5,7 @@ namespace NewPlatform.SuperSimpleContactList
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using ICSSoft.STORMNET;
     using ICSSoft.STORMNET.Business;
 
@@ -58,6 +59,11 @@ namespace NewPlatform.SuperSimpleContactList
         private partial Dictionary<Type, string[]> GetPropertyWithoutSetterCheck()
         {
             return new Dictionary<Type, string[]>();
+        }
+
+        private partial IEnumerable<Type> GetTypesWithoutValidViews()
+        {
+            return Enumerable.Empty<Type>();
         }
     }
 }

--- a/src/SuperSimpleContactList/Tests/SuperSimpleContactList.Tests.csproj
+++ b/src/SuperSimpleContactList/Tests/SuperSimpleContactList.Tests.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.15.2" />
     <PackageReference Include="NewPlatform.Flexberry.ORM" Version="6.0.0-beta14" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM.PostgresDataService" Version="6.0.0-beta13" />
     <PackageReference Include="NewPlatform.Flexberry.StyleCopRuleset" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Пара интеграционных и набор модульных тестов, вдохновленных прикладными проектами. Многие модульные тесты можно при случае переделать на правила статического анализа при компиляции, но пока так.

Класс с тестами разбит на два файла - один, с кодом самих тестов, перегенерируется каждый раз, а второй - с имплементацией partial-методов для управления исключениями в тестах, генерируется только при первой генерации.

Дублирование кода получения типов хранимых объектов данных сделано намеренно - не вижу смысла выносить это в какую-то абстракцию/утилиту, поскольку код не такой уж большой и проблем от его дублирования не предвидится.